### PR TITLE
Update auth-related configuration

### DIFF
--- a/src/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/src/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Middleware;
 
-use App\Providers\RouteServiceProvider;
+// use App\Providers\RouteServiceProvider;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -21,7 +21,7 @@ class RedirectIfAuthenticated
 
         foreach ($guards as $guard) {
             if (Auth::guard($guard)->check()) {
-                return redirect(RouteServiceProvider::HOME);
+                return redirect(route('user'));
             }
         }
 

--- a/src/config/session.php
+++ b/src/config/session.php
@@ -168,7 +168,7 @@ return [
     |
     */
 
-    'secure' => env('SESSION_SECURE_COOKIE'),
+    'secure' => env('APP_ENV') === 'local' ? false : env('SESSION_SECURE_COOKIE'),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -17,7 +17,7 @@ use Illuminate\Support\Facades\Route;
 
 Route::middleware(['auth:sanctum'])->get('/user', function (Request $request) {
     return $request->user();
-});
+})->name('user');
 
 Route::prefix('v1')->group(function () {
     RouteHelper::includeRouteFiles(__DIR__.'/api/v1');

--- a/src/routes/auth/breeze.php
+++ b/src/routes/auth/breeze.php
@@ -9,29 +9,29 @@ use App\Http\Controllers\Auth\VerifyEmailController;
 use Illuminate\Support\Facades\Route;
 
 Route::post('/register', [RegisteredUserController::class, 'store'])
-                ->middleware('guest')
-                ->name('register');
+  ->middleware('guest')
+  ->name('register');
 
 Route::post('/login', [AuthenticatedSessionController::class, 'store'])
-                ->middleware('guest')
-                ->name('login');
+  ->middleware('guest')
+  ->name('login');
 
 Route::post('/forgot-password', [PasswordResetLinkController::class, 'store'])
-                ->middleware('guest')
-                ->name('password.email');
+  ->middleware('guest')
+  ->name('password.email');
 
 Route::post('/reset-password', [NewPasswordController::class, 'store'])
-                ->middleware('guest')
-                ->name('password.store');
+  ->middleware('guest')
+  ->name('password.store');
 
 Route::get('/verify-email/{id}/{hash}', VerifyEmailController::class)
-                ->middleware(['auth', 'signed', 'throttle:6,1'])
-                ->name('verification.verify');
+  ->middleware(['auth', 'signed', 'throttle:6,1'])
+  ->name('verification.verify');
 
 Route::post('/email/verification-notification', [EmailVerificationNotificationController::class, 'store'])
-                ->middleware(['auth', 'throttle:6,1'])
-                ->name('verification.send');
+  ->middleware(['auth', 'throttle:6,1'])
+  ->name('verification.send');
 
 Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])
-                ->middleware('auth')
-                ->name('logout');
+  ->middleware('auth')
+  ->name('logout');

--- a/src/routes/auth/github.php
+++ b/src/routes/auth/github.php
@@ -16,7 +16,7 @@ Route::get('/github/callback', function () {
         $user = User::updateOrCreate(
             ['github_id' => $githubUser->id],
             [
-                'username' => $githubUser->nickname ?? $githubUser->name,
+                'username' => $githubUser->nickname ?? $githubUser->name, // TODO: make uuid if both are null
                 'email' => $githubUser->email,
                 'email_verified_at' => date('Y-m-d H:i:s'),
                 'github_token' => $githubUser->token,

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -24,5 +24,5 @@ Route::get('/', function () {
         dump(Auth::user()?->getAttributes());
     }
 
-    return '<h1>'.$authStatus.'</h1>';
+    return "<h1>{$authStatus}</h1>";
 });


### PR DESCRIPTION
- Disable session cookie https requirement in development mode. Works in browser localhost, but does not send cookies properly in Postman.

- Change `guest` middleware redirect path. Returns user json instead of web.php root /
  - Add a route name to the /user path to easily refer to the route as `route('user')`

- Apply pint formatting to breeze auth routes