### PR TITLE
Redirect OAuth to SPA frontend

### DIFF
--- a/src/routes/auth/discord.php
+++ b/src/routes/auth/discord.php
@@ -26,8 +26,8 @@ Route::get('/discord/callback', function () {
 
         Auth::login($user);
 
-        return redirect('/');
+        return redirect(config('app.frontend_url'));
     } catch (\Exception) {
-        return redirect('/');
+        return redirect(config('app.frontend_url'));
     }
 });

--- a/src/routes/auth/github.php
+++ b/src/routes/auth/github.php
@@ -26,9 +26,9 @@ Route::get('/github/callback', function () {
 
         Auth::login($user);
 
-        return redirect('/');
+        return redirect(config('app.frontend_url'));
     } catch (\Exception) {
         // return redirect(config('view.frontendUrl'));
-        return redirect('/');
+        return redirect(config('app.frontend_url'));
     }
 });

--- a/src/routes/auth/gitlab.php
+++ b/src/routes/auth/gitlab.php
@@ -26,8 +26,8 @@ Route::get('/gitlab/callback', function () {
 
         Auth::login($user);
 
-        return redirect('/');
+        return redirect(config('app.frontend_url'));
     } catch (\Exception) {
-        return redirect('/');
+        return redirect(config('app.frontend_url'));
     }
 });

--- a/src/routes/auth/google.php
+++ b/src/routes/auth/google.php
@@ -26,8 +26,8 @@ Route::get('/google/callback', function () {
 
         Auth::login($user);
 
-        return redirect('/');
+        return redirect(config('app.frontend_url'));
     } catch (\Exception) {
-        return redirect('/');
+        return redirect(config('app.frontend_url'));
     }
 });

--- a/src/routes/auth/reddit.php
+++ b/src/routes/auth/reddit.php
@@ -26,8 +26,8 @@ Route::get('/reddit/callback', function () {
 
         Auth::login($user);
 
-        return redirect('/');
+        return redirect(config('app.frontend_url'));
     } catch (\Exception) {
-        return redirect('/');
+        return redirect(config('app.frontend_url'));
     }
 });


### PR DESCRIPTION
Redirect the user to the frontend upon successful/unsuccessful OAuth.

TODO: append a query param to the redirect route, so the frontend can show a success/failure notification.